### PR TITLE
fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,11 @@ jobs:
         with:
           python-version: "3.6"
 
-      - name: Upgrade pi
+      - name: Upgrade pip
         run: pip install --upgrade pip
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Install requirements
         run: pip install setuptools wheel twine


### PR DESCRIPTION
Failed for [`v0.1.0`](https://github.com/pmeier/pytorch_wheel_installer/actions/runs/140668545)